### PR TITLE
fix: use ArithmeticException for divide by zero

### DIFF
--- a/Calculator.java
+++ b/Calculator.java
@@ -13,7 +13,7 @@ public class Calculator {
 
     public double divide(int a, int b) {
         if (b == 0) {
-            throw new IllegalArgumentException("Cannot divide by zero");
+throw new ArithmeticException("Cannot divide by zero");
         }
         return (double) a / b;
     }


### PR DESCRIPTION
Hotfix: sửa method divide(int a, int b) để ném ArithmeticException thay vì IllegalArgumentException.
Lý do: ArithmeticException chuẩn cho lỗi chia cho 0 trong Java.
